### PR TITLE
Use model attribute translation as fallback for form attributes

### DIFF
--- a/lib/formwandler/field_definition.rb
+++ b/lib/formwandler/field_definition.rb
@@ -5,11 +5,39 @@ require_relative 'field_value_transformer'
 module Formwandler
   class FieldDefinition
     attr_reader :name
-    attr_accessor :hidden, :disabled, :readonly, :default, :delocalize, :model, :source, :options, :array
+    attr_accessor :hidden, :disabled, :readonly, :default, :delocalize, :model, :model_class, :source, :options, :array
 
     def initialize(name)
       @name = name
       set_defaults
+    end
+
+    def model=(model)
+      set_model model, model
+    end
+
+    def model_class=(symbol_or_class)
+      @model_class =
+        if symbol_or_class.nil?
+          nil
+        elsif symbol_or_class.is_a?(Symbol)
+          symbol_or_class.to_s.classify.constantize rescue nil
+        elsif symbol_or_class < ActiveRecord::Base || symbol_or_class < ActiveModel::Model
+          symbol_or_class
+        else
+          fail 'The model class must be nil, a symbol or a descendant of ActiveModel::Model or ActiveRecord::Base.'
+        end
+    end
+
+    def configure(opts)
+      model = opts[:model]
+      model_class = opts[:model_class] || model
+      set_model model, model_class
+      opts.except(:model, :model_class).each do |key, value|
+        send("#{key}=", value)
+      rescue NoMethodError
+        raise ArgumentError, "Invalid option #{key}"
+      end
     end
 
     def hide_option(name, value = true)
@@ -43,9 +71,15 @@ module Formwandler
       @default = nil
       @delocalize = nil
       @model = nil
+      @model_class = nil
       @source = name
       @options = nil
       @array = false
+    end
+
+    def set_model(model, model_class)
+      @model = model
+      self.model_class = model_class
     end
   end
 end

--- a/spec/dummy/app/models/unrelated_model.rb
+++ b/spec/dummy/app/models/unrelated_model.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UnrelatedModel < ApplicationRecord
+end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -31,3 +31,14 @@
 
 en:
   hello: "Hello world"
+  activemodel:
+    attributes:
+      my_model:
+        field1: 'Field1 directly'
+        field3: 'Field3 directly'
+  activerecord:
+    attributes:
+      my_model:
+        field2: 'Field2 by model'
+        field3: 'Not used'
+        other_field: 'Field4 by model'

--- a/spec/dummy/db/migrate/20181112220854_create_unrelated_model.rb
+++ b/spec/dummy/db/migrate/20181112220854_create_unrelated_model.rb
@@ -1,0 +1,9 @@
+class CreateUnrelatedModel < ActiveRecord::Migration[5.2]
+  def change
+    create_table :unrelated_models do |t|
+      t.string :some_field
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170915080828) do
+ActiveRecord::Schema.define(version: 2018_11_12_220854) do
 
   create_table "my_models", force: :cascade do |t|
     t.string "field1"
@@ -20,6 +20,12 @@ ActiveRecord::Schema.define(version: 20170915080828) do
     t.decimal "transformed_field"
     t.string "other_field"
     t.boolean "boolean_field"
+  end
+
+  create_table "unrelated_models", force: :cascade do |t|
+    t.string "some_field"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/field_definition_spec.rb
+++ b/spec/field_definition_spec.rb
@@ -31,4 +31,46 @@ RSpec.describe Formwandler::FieldDefinition do
       end
     end
   end
+
+  describe '#model=' do
+    subject(:assign_model) { field_definition.model = new_model }
+
+    shared_examples_for 'changing #model' do |from:, to:|
+      it "from #{from} to #{to}" do
+        expect { subject }.to change { field_definition.model }.from(from).to(to)
+      end
+    end
+
+    context 'when the model class is inferrable' do
+      let(:new_model) { :my_model }
+
+      it_behaves_like 'changing #model', from: nil, to: :my_model
+
+      it 'sets the inferred model class' do
+        expect { subject }.to change { field_definition.model_class }.from(nil).to(MyModel)
+      end
+    end
+
+    context 'when the model class is not inferrable' do
+      let(:new_model) { :not_inferrable }
+
+      context 'when @model_class=nil' do
+        it_behaves_like 'changing #model', from: nil, to: :not_inferrable
+
+        it 'does not change the model class' do
+          expect { subject }.not_to change { field_definition.model_class }.from(nil)
+        end
+      end
+
+      context 'when @model_class=UnrelatedModel' do
+        before { field_definition.model_class = UnrelatedModel }
+
+        it_behaves_like 'changing #model', from: nil, to: :not_inferrable
+
+        it 'does not change the model class' do
+          expect { subject }.to change { field_definition.model_class }.from(UnrelatedModel).to(nil)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When #human_attribute_name is called on a `Form` and the respective
field is backed by a model then the translation for the field's source
attribute will be injected as default into the translation lookup.

If a default is explicitly passed into #human_attribute_name then this
has precedence over the source attribute translation.

Closes #15